### PR TITLE
#123 Support module nested references loading in Platform modular system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,4 @@ __pycache__/
 /VirtoCommerce.Platform.Web/wwwroot/App_Data
 /VirtoCommerce.Platform.Web/wwwroot/maps
 /VirtoCommerce.Platform.Web/wwwroot/assets
+/VirtoCommerce.Platform.Web/wwwroot/dist

--- a/Modules/Module1/Module1.Abstractions/IMyService.cs
+++ b/Modules/Module1/Module1.Abstractions/IMyService.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Module1.Abstractions
 {
     public interface IMyService

--- a/Modules/Module1/Module1.Abstractions/IThirdPartyService.cs
+++ b/Modules/Module1/Module1.Abstractions/IThirdPartyService.cs
@@ -1,0 +1,7 @@
+namespace Module1.Abstractions
+{
+    public interface IThirdPartyService
+    {
+        string CallThirdPartyMethodFromAnotherProject(string message);
+    }
+}

--- a/Modules/Module1/Module1.Data/Module1.Data.csproj
+++ b/Modules/Module1/Module1.Data/Module1.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/Modules/Module1/Module1.Data/Module1.Data.csproj
+++ b/Modules/Module1/Module1.Data/Module1.Data.csproj
@@ -4,15 +4,21 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath></OutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
+    <PackageReference Include="SharpZipLib" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\VirtoCommerce.Platform.Data\VirtoCommerce.Platform.Data.csproj" />
+    <ProjectReference Include="..\Module1.Abstractions\Module1.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Modules/Module1/Module1.Data/Services/MyThirdPartyService.cs
+++ b/Modules/Module1/Module1.Data/Services/MyThirdPartyService.cs
@@ -13,8 +13,8 @@ namespace Module1.Data.Services
         {
             var bytes = Encoding.UTF8.GetBytes(message);
             using (var inStream = new MemoryStream(bytes))
+            using (var outStream = CreateToMemoryStream(inStream, "TestZipEntry"))
             {
-                var outStream = CreateToMemoryStream(inStream, "TestZipEntry");
                 return $"Zipped message UTF-8 decoded string is:{Encoding.UTF8.GetString(outStream.ToArray())}";
             }
         }

--- a/Modules/Module1/Module1.Data/Services/MyThirdPartyService.cs
+++ b/Modules/Module1/Module1.Data/Services/MyThirdPartyService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.Zip;
+using Module1.Abstractions;
+
+namespace Module1.Data.Services
+{
+    public class ThirdPartyServiceImpl : IThirdPartyService
+    {
+        public string CallThirdPartyMethodFromAnotherProject(string message)
+        {
+            var bytes = Encoding.UTF8.GetBytes(message);
+            using (var inStream = new MemoryStream(bytes))
+            {
+                var outStream = CreateToMemoryStream(inStream, "TestZipEntry");
+                return $"Zipped message UTF-8 decoded string is:{Encoding.UTF8.GetString(outStream.ToArray())}";
+            }
+        }
+
+        // From https://github.com/icsharpcode/SharpZipLib/wiki/Zip-Samples#create-a-zip-fromto-a-memory-stream-or-byte-array
+        private MemoryStream CreateToMemoryStream(MemoryStream memStreamIn, string zipEntryName)
+        {
+            var outputMemStream = new MemoryStream();
+            var zipStream = new ZipOutputStream(outputMemStream);
+
+            zipStream.SetLevel(3); //0-9, 9 being the highest level of compression
+
+            var newEntry = new ZipEntry(zipEntryName);
+            newEntry.DateTime = DateTime.Now;
+
+            zipStream.PutNextEntry(newEntry);
+
+            StreamUtils.Copy(memStreamIn, zipStream, new byte[4096]);
+            zipStream.CloseEntry();
+
+            zipStream.IsStreamOwner = false;    // False stops the Close also Closing the underlying stream.
+            zipStream.Close();          // Must finish the ZipOutputStream before using outputMemStream.
+
+            outputMemStream.Position = 0;
+            return outputMemStream;
+        }
+    }
+}

--- a/Modules/Module1/Module1.Test/AssemblyLoadTest.cs
+++ b/Modules/Module1/Module1.Test/AssemblyLoadTest.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+using VirtoCommerce.Platform.Modules;
+using Xunit;
+
+namespace Module1.Test
+{
+    public class AssemblyLoadTest
+    {
+        [Fact]
+        public void TestAssemblyLoadThroughReflection()
+        {
+            var logger = Mock.Of<ILogger<LoadContextAssemblyResolver>>();
+            var resolver = new LoadContextAssemblyResolver(logger);
+            var webRuntimeAssembly = resolver.LoadAssemblyFrom($"{AppContext.BaseDirectory}..\\..\\..\\Module1.Web\\bin\\netcoreapp2.1\\Module1.Web.dll");
+
+            // Uncommenting this line makes the trick - test passes (as we explicitly load dependency of referenced assembly Module1.Data,
+            // that is not loaded by LoadContextAssemblyResolver.LoadAssemblyFrom one level deps resolving now)
+            // System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(@"C:\Users\yecli\.nuget\packages\sharpziplib\1.1.0\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll");
+            var controllerType = webRuntimeAssembly.GetType("Module1.Web.Controllers.ThirdPartyController");
+            var controllerInstance = Activator.CreateInstance(controllerType);
+            var stringResult = (string)controllerType.GetMethod("Execute3rdPartyCodeFromDifferentProject").Invoke(controllerInstance, new object[] { "Aloha!" });
+
+            Assert.NotNull(stringResult);
+        }
+    }
+}

--- a/Modules/Module1/Module1.Test/AssemblyLoadTest.cs
+++ b/Modules/Module1/Module1.Test/AssemblyLoadTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using VirtoCommerce.Platform.Modules;
@@ -9,23 +10,43 @@ namespace Module1.Test
     [Trait("Category", "CI")]
     public class AssemblyLoadTest
     {
-        [Fact]
-        public void TestAssemblyLoadThroughReflection()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadAssemblyFrom_ThirdPartyAssemblyInDependentProject_IsLoadedCorrectly(bool isDevelopmentEnvironment)
         {
-            var logger = Mock.Of<ILogger<LoadContextAssemblyResolver>>();
-            var resolver = new LoadContextAssemblyResolver(logger);
-            var webRuntimeAssembly = resolver.LoadAssemblyFrom($"{AppContext.BaseDirectory}..\\..\\..\\Module1.Web\\bin\\netcoreapp2.1\\Module1.Web.dll");
+            // Arrange
+            var loggerStub = Mock.Of<ILogger<LoadContextAssemblyResolver>>();
+            var resolver = new LoadContextAssemblyResolver(loggerStub, isDevelopmentEnvironment);
 
-            // Explicit loading of "ICSharpCode.SharpZipLib.dll" (dependency of referenced assembly Module1.Data) to default ALC would make test passing even without proper dependency loading:
-            // System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(Environment.ExpandEnvironmentVariables(@"%userprofile%\.nuget\packages\sharpziplib\1.1.0\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll"));
-            var controllerType = webRuntimeAssembly.GetType("Module1.Web.Controllers.ThirdPartyController");
-            Assert.NotNull(controllerType);
-            var controllerInstance = Activator.CreateInstance(controllerType);
-            var method = controllerType.GetMethod("Execute3rdPartyCodeFromDifferentProject");
-            Assert.NotNull(method);
-            var stringResult = (string)method.Invoke(controllerInstance, new object[] { "Aloha!" });
+            // Act
+            var webRuntimeAssembly = LoadAssemblyInRuntime(resolver);
+            // To ensure assembly is loaded correctly with all recursive dependencies, need to instantiate controller and call the method that call third party dll functions
+            var stringResult = CallControllerMethod(webRuntimeAssembly);
 
+            // Assert
             Assert.NotNull(stringResult);
+        }
+
+        private static Assembly LoadAssemblyInRuntime(LoadContextAssemblyResolver resolver)
+        {
+            // We need to load assembly that is not referenced by our project, thats why physical path is hardcoded
+            var Module1WebModulePath = $"{AppContext.BaseDirectory}..\\..\\..\\Module1.Web\\bin\\netcoreapp2.1\\Module1.Web.dll";
+            var webRuntimeAssembly = resolver.LoadAssemblyFrom(Module1WebModulePath);
+            return webRuntimeAssembly;
+        }
+
+        private static string CallControllerMethod(Assembly webRuntimeAssembly)
+        {
+            // We need to use type and method string names instead of nameof() here as we should not have the reference to these assemblies for proper load testing
+            const string ControllerTypeFullName = "Module1.Web.Controllers.ThirdPartyController";
+            const string ControllerMethodName = "Execute3rdPartyCodeFromDifferentProject";
+            const string ControllerMethodSampleArgument = "Sample message.";
+
+            var controllerType = webRuntimeAssembly.GetType(ControllerTypeFullName);
+            var controllerInstance = Activator.CreateInstance(controllerType);
+            var method = controllerType.GetMethod(ControllerMethodName);
+            return (string)method.Invoke(controllerInstance, new object[] { ControllerMethodSampleArgument });
         }
     }
 }

--- a/Modules/Module1/Module1.Test/Module1.Test.csproj
+++ b/Modules/Module1/Module1.Test/Module1.Test.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\VirtoCommerce.Platform.Modules\VirtoCommerce.Platform.Modules.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions">
+      <HintPath>..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.logging.abstractions\2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Modules/Module1/Module1.Test/Module1.Test.csproj
+++ b/Modules/Module1/Module1.Test/Module1.Test.csproj
@@ -22,9 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions">
-      <HintPath>..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.logging.abstractions\2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions"/>
   </ItemGroup>
 
 </Project>

--- a/Modules/Module1/Module1.Web/Controllers/ThirdPartyController.cs
+++ b/Modules/Module1/Module1.Web/Controllers/ThirdPartyController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+using Module1.Data.Services;
+
+namespace Module1.Web.Controllers
+{
+    [Route("api/[controller]")]
+    public class ThirdPartyController
+    {
+        public ThirdPartyController()
+        {
+        }
+
+        // GET api/thirdparty
+        [HttpGet]
+        public string Execute3rdPartyCodeFromDifferentProject(string message)
+        {
+            return new ThirdPartyServiceImpl().CallThirdPartyMethodFromAnotherProject(message);
+        }
+    }
+}

--- a/Modules/Module1/Module1.Web/Module.cs
+++ b/Modules/Module1/Module1.Web/Module.cs
@@ -1,16 +1,13 @@
-using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Module1.Abstractions;
 using Module1.Data;
+using Module1.Data.Services;
 using Module1.Services;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Modularity;
-using VirtoCommerce.Platform.Core.Settings;
-using VirtoCommerce.Platform.Data.Model;
 using VirtoCommerce.Platform.Data.Repositories;
 
 namespace Module1.Web
@@ -24,6 +21,7 @@ namespace Module1.Web
             var configuration = serviceCollection.BuildServiceProvider().GetRequiredService<IConfiguration>();
             //var mode = FluentValidation.CascadeMode.Continue;
             serviceCollection.AddSingleton<IMyService, MyServiceImpl>();
+            serviceCollection.AddSingleton<IThirdPartyService, ThirdPartyServiceImpl>();
             serviceCollection.AddDbContext<PlatformDbContext2>(builder =>
             {
                 builder.UseSqlServer(configuration.GetConnectionString("VirtoCommerce"));

--- a/Modules/Module1/Module1.Web/Module1.Web.csproj
+++ b/Modules/Module1/Module1.Web/Module1.Web.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
      <TargetFramework>netcoreapp2.1</TargetFramework>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
-     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+     <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/Module1/Module1.Web/Module1.Web.csproj
+++ b/Modules/Module1/Module1.Web/Module1.Web.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
      <TargetFramework>netcoreapp2.1</TargetFramework>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/Module1/Module1.Web/Module1.Web.csproj
+++ b/Modules/Module1/Module1.Web/Module1.Web.csproj
@@ -4,6 +4,10 @@
      <TargetFramework>netcoreapp2.1</TargetFramework>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.0.101" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.6" />

--- a/Modules/vc-module-cart/VirtoCommerce.CartModule.Web/VirtoCommerce.CartModule.Web.csproj
+++ b/Modules/vc-module-cart/VirtoCommerce.CartModule.Web/VirtoCommerce.CartModule.Web.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-cart/VirtoCommerce.CartModule.Web/VirtoCommerce.CartModule.Web.csproj
+++ b/Modules/vc-module-cart/VirtoCommerce.CartModule.Web/VirtoCommerce.CartModule.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
       <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Web/VirtoCommerce.CatalogModule.Web.csproj
+++ b/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Web/VirtoCommerce.CatalogModule.Web.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!--This line is necessary to copy all dependencies in the bin folder-->
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Web/VirtoCommerce.CatalogModule.Web.csproj
+++ b/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Web/VirtoCommerce.CatalogModule.Web.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!--This line is necessary to copy all dependencies in the bin folder-->
-        <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-core/VirtoCommerce.CoreModule.Web/VirtoCommerce.CoreModule.Web.csproj
+++ b/Modules/vc-module-core/VirtoCommerce.CoreModule.Web/VirtoCommerce.CoreModule.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-core/VirtoCommerce.CoreModule.Web/VirtoCommerce.CoreModule.Web.csproj
+++ b/Modules/vc-module-core/VirtoCommerce.CoreModule.Web/VirtoCommerce.CoreModule.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-customer/VirtoCommerce.CustomerModule.Web/VirtoCommerce.CustomerModule.Web.csproj
+++ b/Modules/vc-module-customer/VirtoCommerce.CustomerModule.Web/VirtoCommerce.CustomerModule.Web.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
     <ItemGroup>

--- a/Modules/vc-module-customer/VirtoCommerce.CustomerModule.Web/VirtoCommerce.CustomerModule.Web.csproj
+++ b/Modules/vc-module-customer/VirtoCommerce.CustomerModule.Web/VirtoCommerce.CustomerModule.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
     <ItemGroup>

--- a/Modules/vc-module-imageTools/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
+++ b/Modules/vc-module-imageTools/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-imageTools/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
+++ b/Modules/vc-module-imageTools/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--<RuntimeIdentifier>win10-x64</RuntimeIdentifier>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-inventory/VirtoCommerce.InventoryModule.Web/VirtoCommerce.InventoryModule.Web.csproj
+++ b/Modules/vc-module-inventory/VirtoCommerce.InventoryModule.Web/VirtoCommerce.InventoryModule.Web.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-inventory/VirtoCommerce.InventoryModule.Web/VirtoCommerce.InventoryModule.Web.csproj
+++ b/Modules/vc-module-inventory/VirtoCommerce.InventoryModule.Web/VirtoCommerce.InventoryModule.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-licensing/VirtoCommerce.LicensingModule.Web/VirtoCommerce.LicensingModule.Web.csproj
+++ b/Modules/vc-module-licensing/VirtoCommerce.LicensingModule.Web/VirtoCommerce.LicensingModule.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-licensing/VirtoCommerce.LicensingModule.Web/VirtoCommerce.LicensingModule.Web.csproj
+++ b/Modules/vc-module-licensing/VirtoCommerce.LicensingModule.Web/VirtoCommerce.LicensingModule.Web.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-lucene-search/VirtoCommerce.LuceneSearchModule.Web/VirtoCommerce.LuceneSearchModule.Web.csproj
+++ b/Modules/vc-module-lucene-search/VirtoCommerce.LuceneSearchModule.Web/VirtoCommerce.LuceneSearchModule.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modules/vc-module-lucene-search/VirtoCommerce.LuceneSearchModule.Web/VirtoCommerce.LuceneSearchModule.Web.csproj
+++ b/Modules/vc-module-lucene-search/VirtoCommerce.LuceneSearchModule.Web/VirtoCommerce.LuceneSearchModule.Web.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modules/vc-module-notifications/VirtoCommerce.NotificationsModule.Web/VirtoCommerce.NotificationsModule.Web.csproj
+++ b/Modules/vc-module-notifications/VirtoCommerce.NotificationsModule.Web/VirtoCommerce.NotificationsModule.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-notifications/VirtoCommerce.NotificationsModule.Web/VirtoCommerce.NotificationsModule.Web.csproj
+++ b/Modules/vc-module-notifications/VirtoCommerce.NotificationsModule.Web/VirtoCommerce.NotificationsModule.Web.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-orders/VirtoCommerce.OrdersModule.Web/VirtoCommerce.OrdersModule.Web.csproj
+++ b/Modules/vc-module-orders/VirtoCommerce.OrdersModule.Web/VirtoCommerce.OrdersModule.Web.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!--This line is necessary to copy all dependencies in the bin folder-->
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-orders/VirtoCommerce.OrdersModule.Web/VirtoCommerce.OrdersModule.Web.csproj
+++ b/Modules/vc-module-orders/VirtoCommerce.OrdersModule.Web/VirtoCommerce.OrdersModule.Web.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!--This line is necessary to copy all dependencies in the bin folder-->
-        <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-search/VirtoCommerce.SearchModule.Web/VirtoCommerce.SearchModule.Web.csproj
+++ b/Modules/vc-module-search/VirtoCommerce.SearchModule.Web/VirtoCommerce.SearchModule.Web.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-search/VirtoCommerce.SearchModule.Web/VirtoCommerce.SearchModule.Web.csproj
+++ b/Modules/vc-module-search/VirtoCommerce.SearchModule.Web/VirtoCommerce.SearchModule.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-sitemaps/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
+++ b/Modules/vc-module-sitemaps/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modules/vc-module-sitemaps/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
+++ b/Modules/vc-module-sitemaps/VirtoCommerce.SitemapsModule.Web/VirtoCommerce.SitemapsModule.Web.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modules/vc-module-store/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
+++ b/Modules/vc-module-store/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-store/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
+++ b/Modules/vc-module-store/VirtoCommerce.StoreModule.Web/VirtoCommerce.StoreModule.Web.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <!--This line is necessary to copy all dependencies in the bin folder-->
-      <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Modules/vc-module-subscriptions/VirtoCommerce.SubscriptionModule.Web/VirtoCommerce.SubscriptionModule.Web.csproj
+++ b/Modules/vc-module-subscriptions/VirtoCommerce.SubscriptionModule.Web/VirtoCommerce.SubscriptionModule.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!--This line is necessary to copy all dependencies in the bin folder-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modules/vc-module-subscriptions/VirtoCommerce.SubscriptionModule.Web/VirtoCommerce.SubscriptionModule.Web.csproj
+++ b/Modules/vc-module-subscriptions/VirtoCommerce.SubscriptionModule.Web/VirtoCommerce.SubscriptionModule.Web.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <!--This line is necessary to copy all dependencies in the bin folder-->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VirtoCommerce.Platform.Core/Modularity/LocalStorageModuleCatalogOptions.cs
+++ b/VirtoCommerce.Platform.Core/Modularity/LocalStorageModuleCatalogOptions.cs
@@ -4,6 +4,7 @@ namespace VirtoCommerce.Platform.Core.Modularity
     {
         public string DiscoveryPath { get; set; }
         public string ProbingPath { get; set; }
-        public string[] AssemblyFileExtensions { get; set; } = new[] { ".dll", ".pdb", ".exe", ".xml", ".deps.json" };
+        public string[] AssemblyFileExtensions { get; set; } = new[] { ".dll", ".exe", };
+        public string[] AssemblyServiceFileExtensions { get; set; } = new[] { ".pdb", ".xml", ".deps.json", };
     }
 }

--- a/VirtoCommerce.Platform.Core/Modularity/LocalStorageModuleCatalogOptions.cs
+++ b/VirtoCommerce.Platform.Core/Modularity/LocalStorageModuleCatalogOptions.cs
@@ -5,6 +5,6 @@ namespace VirtoCommerce.Platform.Core.Modularity
         public string DiscoveryPath { get; set; }
         public string ProbingPath { get; set; }
         public string[] AssemblyFileExtensions { get; set; } = new[] { ".dll", ".exe", };
-        public string[] AssemblyServiceFileExtensions { get; set; } = new[] { ".pdb", ".xml", ".deps.json", };
+        public string[] AssemblyServiceFileExtensions { get; set; } = new[] { ".pdb", ".xml", ".deps.json", ".runtimeconfig.json", ".runtimeconfig.dev.json", };
     }
 }

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/DependencyContextExtensions.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/DependencyContextExtensions.cs
@@ -7,14 +7,14 @@ using Microsoft.Extensions.DependencyModel;
 namespace VirtoCommerce.Platform.Modules.AssemblyLoading
 {
     // Based on https://github.com/natemcmaster/DotNetCorePlugins/blob/ce1b5cc94e8e9ce018f9304368cc69897cc70cca/src/Plugins/Loader/DependencyContextExtensions.cs
-    public static class DependencyReader
+    public static class DependencyContextExtensions
     {
         /// <summary>
         /// Get dependency list from a .deps.json file.
         /// </summary>
         /// <param name="depsFilePath">The full path to the .deps.json file.</param>
         /// <returns>Returns all assembly dependencies.</returns>
-        public static IEnumerable<ManagedLibrary> ExtractDependencies(string depsFilePath)
+        public static IEnumerable<ManagedLibrary> ExtractDependenciesFromPath(this string depsFilePath)
         {
             var reader = new DependencyContextJsonReader();
             using (var file = File.OpenRead(depsFilePath))
@@ -29,7 +29,7 @@ namespace VirtoCommerce.Platform.Modules.AssemblyLoading
         /// </summary>
         /// <param name="dependencyContext">The dependency context.</param>
         /// <returns>Returns all assembly dependencies.</returns>
-        public static IEnumerable<ManagedLibrary> ExtractDependencies(DependencyContext dependencyContext)
+        public static IEnumerable<ManagedLibrary> ExtractDependencies(this DependencyContext dependencyContext)
         {
             var ridGraph = dependencyContext.RuntimeGraph.Any()
                ? dependencyContext.RuntimeGraph
@@ -86,9 +86,7 @@ namespace VirtoCommerce.Platform.Modules.AssemblyLoading
         private static IEnumerable<ManagedLibrary> ResolveRuntimeAssemblies(DependencyContext depContext, RuntimeFallbacks runtimeGraph)
         {
             var rids = GetRids(runtimeGraph);
-            return from library in depContext.RuntimeLibraries
-                   from assetPath in SelectAssets(rids, library.RuntimeAssemblyGroups)
-                   select ManagedLibrary.CreateFromPackage(library.Name, library.Version, assetPath);
+            return depContext.RuntimeLibraries.SelectMany(x => SelectAssets(rids, x.RuntimeAssemblyGroups).Select(assetPath => ManagedLibrary.CreateFromPackage(x.Name, x.Version, assetPath)));
         }
 
         private static IEnumerable<string> GetRids(RuntimeFallbacks runtimeGraph)

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/DependencyReader.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/DependencyReader.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyModel;
+
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    // Based on https://github.com/natemcmaster/DotNetCorePlugins/blob/ce1b5cc94e8e9ce018f9304368cc69897cc70cca/src/Plugins/Loader/DependencyContextExtensions.cs
+    public static class DependencyReader
+    {
+        /// <summary>
+        /// Get dependency list from a .deps.json file.
+        /// </summary>
+        /// <param name="depsFilePath">The full path to the .deps.json file.</param>
+        /// <returns>Returns all assembly dependencies.</returns>
+        public static IEnumerable<ManagedLibrary> ExtractDependencies(string depsFilePath)
+        {
+            var reader = new DependencyContextJsonReader();
+            using (var file = File.OpenRead(depsFilePath))
+            {
+                var deps = reader.Read(file);
+                return ExtractDependencies(deps);
+            }
+        }
+
+        /// <summary>
+        /// Get dependency list form pre-parsed <see cref="DependencyContext" />.
+        /// </summary>
+        /// <param name="dependencyContext">The dependency context.</param>
+        /// <returns>Returns all assembly dependencies.</returns>
+        public static IEnumerable<ManagedLibrary> ExtractDependencies(DependencyContext dependencyContext)
+        {
+            var ridGraph = dependencyContext.RuntimeGraph.Any()
+               ? dependencyContext.RuntimeGraph
+               : DependencyContext.Default.RuntimeGraph;
+
+            var rid = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+            var fallbackRid = GetFallbackRid();
+            var fallbackGraph = ridGraph.FirstOrDefault(g => g.Runtime == rid)
+                ?? ridGraph.FirstOrDefault(g => g.Runtime == fallbackRid)
+                ?? new RuntimeFallbacks("any");
+
+            return ResolveRuntimeAssemblies(dependencyContext, fallbackGraph);
+        }
+
+        private static string GetFallbackRid()
+        {
+            // see https://github.com/dotnet/core-setup/blob/b64f7fffbd14a3517186b9a9d5cc001ab6e5bde6/src/corehost/common/pal.h#L53-L73
+
+            string ridBase;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                ridBase = "win10";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                ridBase = "linux";
+
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                ridBase = "osx.10.12";
+            }
+            else
+            {
+                return "any";
+            }
+
+            switch (RuntimeInformation.OSArchitecture)
+            {
+                case Architecture.X86:
+                    return ridBase + "-x86";
+                case Architecture.X64:
+                    return ridBase + "-x64";
+                case Architecture.Arm:
+                    return ridBase + "-arm";
+                case Architecture.Arm64:
+                    return ridBase + "-arm64";
+            }
+
+            return ridBase;
+        }
+
+        private static IEnumerable<ManagedLibrary> ResolveRuntimeAssemblies(DependencyContext depContext, RuntimeFallbacks runtimeGraph)
+        {
+            var rids = GetRids(runtimeGraph);
+            return from library in depContext.RuntimeLibraries
+                   from assetPath in SelectAssets(rids, library.RuntimeAssemblyGroups)
+                   select ManagedLibrary.CreateFromPackage(library.Name, library.Version, assetPath);
+        }
+
+        private static IEnumerable<string> GetRids(RuntimeFallbacks runtimeGraph)
+        {
+            return new[] { runtimeGraph.Runtime }.Concat(runtimeGraph?.Fallbacks ?? Enumerable.Empty<string>());
+        }
+
+        private static IEnumerable<string> SelectAssets(IEnumerable<string> rids, IEnumerable<RuntimeAssetGroup> groups)
+        {
+            foreach (var rid in rids)
+            {
+                var group = groups.FirstOrDefault(g => g.Runtime == rid);
+                if (group != null)
+                {
+                    return group.AssetPaths;
+                }
+            }
+
+            // Return the RID-agnostic group
+            return groups.GetDefaultAssets();
+        }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/ManagedAssemblyLoadContext.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/ManagedAssemblyLoadContext.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    public class ManagedAssemblyLoadContext
+    {
+        public string BasePath { get; set; }
+        public IEnumerable<string> AdditionalProdingPath { get; set; }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/ManagedLibrary.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/ManagedLibrary.cs
@@ -1,0 +1,66 @@
+// https://github.com/natemcmaster/DotNetCorePlugins/blob/1001cdede224c0d335f21ec7b1a9f3fa7ad7fa84/src/Plugins/LibraryModel/ManagedLibrary.cs
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    // Copyright (c) Nate McMaster.
+    // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+    /// <summary>
+    /// Represents a managed, .NET assembly.
+    /// </summary>
+    [DebuggerDisplay("{Name} = {AdditionalProbingPath}")]
+    public class ManagedLibrary
+    {
+        /// <summary>
+        /// Name of the managed library
+        /// </summary>
+        public AssemblyName Name { get; private set; }
+
+        /// <summary>
+        /// Contains path to file within an additional probing path root. This is typically a combination
+        /// of the NuGet package ID (lowercased), version, and path within the package.
+        /// <para>
+        /// For example, <c>microsoft.data.sqlite/1.0.0/lib/netstandard1.3/Microsoft.Data.Sqlite.dll</c>
+        /// </para>
+        /// </summary>
+        public string AdditionalProbingPath { get; private set; }
+
+        /// <summary>
+        /// Contains path to file within a deployed, framework-dependent application.
+        /// <para>
+        /// For most managed libraries, this will be the file name.
+        /// For example, <c>MyPlugin1.dll</c>.
+        /// </para>
+        /// <para>
+        /// For runtime-specific managed implementations, this may include a sub folder path.
+        /// For example, <c>runtimes/win/lib/netcoreapp2.0/System.Diagnostics.EventLog.dll</c>
+        /// </para>
+        /// </summary>
+        public string AppLocalPath { get; private set; }
+
+        /// <summary>
+        /// Create an instance of <see cref="ManagedLibrary" /> from a NuGet package.
+        /// </summary>
+        /// <param name="packageId">The name of the package.</param>
+        /// <param name="packageVersion">The version of the package.</param>
+        /// <param name="assetPath">The path within the NuGet package.</param>
+        /// <returns></returns>
+        public static ManagedLibrary CreateFromPackage(string packageId, string packageVersion, string assetPath)
+        {
+            // When the asset comes from "lib/$tfm/", Microsoft.NET.Sdk will flatten this during publish based on the most compatible TFM.
+            // The SDK will not flatten managed libraries found under runtimes/
+            var appLocalPath = assetPath.StartsWith("lib/")
+                ? Path.GetFileName(assetPath)
+                : assetPath;
+
+            return new ManagedLibrary
+            {
+                Name = new AssemblyName(Path.GetFileNameWithoutExtension(assetPath)),
+                AdditionalProbingPath = Path.Combine(packageId.ToLowerInvariant(), packageVersion, assetPath),
+                AppLocalPath = appLocalPath,
+            };
+        }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
@@ -1,0 +1,45 @@
+// https://github.com/natemcmaster/DotNetCorePlugins/blob/1001cdede224c0d335f21ec7b1a9f3fa7ad7fa84/src/Plugins/Internal/PlatformInformation.cs
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    internal class PlatformInformation
+    {
+        public static readonly string[] NativeLibraryExtensions;
+        public static readonly string[] NativeLibraryPrefixes;
+        public static readonly string[] ManagedAssemblyExtensions = new[]
+        {
+                ".dll",
+                ".ni.dll",
+                ".exe",
+                ".ni.exe"
+        };
+
+        static PlatformInformation()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                NativeLibraryPrefixes = new[] { "" };
+                NativeLibraryExtensions = new[] { ".dll" };
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                NativeLibraryPrefixes = new[] { "", "lib", };
+                NativeLibraryExtensions = new[] { ".dylib" };
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                NativeLibraryPrefixes = new[] { "", "lib" };
+                NativeLibraryExtensions = new[] { ".so", ".so.1" };
+            }
+            else
+            {
+                Debug.Fail("Unknown OS type");
+                NativeLibraryPrefixes = Array.Empty<string>();
+                NativeLibraryExtensions = Array.Empty<string>();
+            }
+        }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
@@ -1,11 +1,12 @@
 // https://github.com/natemcmaster/DotNetCorePlugins/blob/1001cdede224c0d335f21ec7b1a9f3fa7ad7fa84/src/Plugins/Internal/PlatformInformation.cs
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace VirtoCommerce.Platform.Modules.AssemblyLoading
 {
-    internal class PlatformInformation
+    internal static class PlatformInformation
     {
         public static readonly string[] NativeLibraryExtensions;
         public static readonly string[] NativeLibraryPrefixes;
@@ -17,6 +18,7 @@ namespace VirtoCommerce.Platform.Modules.AssemblyLoading
                 ".ni.exe"
         };
 
+        [SuppressMessage("SonarLint", "S3963", Justification = "Such conditional initialization looks better in costructor, than inlined.")]
         static PlatformInformation()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
@@ -1,7 +1,8 @@
-// https://github.com/natemcmaster/DotNetCorePlugins/blob/1001cdede224c0d335f21ec7b1a9f3fa7ad7fa84/src/Plugins/Internal/PlatformInformation.cs
+// Based on https://github.com/natemcmaster/DotNetCorePlugins/blob/1001cdede224c0d335f21ec7b1a9f3fa7ad7fa84/src/Plugins/Internal/PlatformInformation.cs
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace VirtoCommerce.Platform.Modules.AssemblyLoading
@@ -17,30 +18,35 @@ namespace VirtoCommerce.Platform.Modules.AssemblyLoading
                 ".exe",
                 ".ni.exe"
         };
+        public static readonly string NuGetPackagesCache;
 
-        [SuppressMessage("SonarLint", "S3963", Justification = "Such conditional initialization looks better in costructor, than inlined.")]
+        [SuppressMessage("SonarLint", "S3963", Justification = "Such conditional initialization looks better in constructor, than inlined.")]
         static PlatformInformation()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 NativeLibraryPrefixes = new[] { "" };
                 NativeLibraryExtensions = new[] { ".dll" };
+                NuGetPackagesCache = Path.Combine(Environment.ExpandEnvironmentVariables("%userprofile%"), ".nuget", "packages");
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 NativeLibraryPrefixes = new[] { "", "lib", };
                 NativeLibraryExtensions = new[] { ".dylib" };
+                NuGetPackagesCache = Path.Combine("~", ".nuget", "packages");
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 NativeLibraryPrefixes = new[] { "", "lib" };
                 NativeLibraryExtensions = new[] { ".so", ".so.1" };
+                NuGetPackagesCache = Path.Combine("~", ".nuget", "packages");
             }
             else
             {
                 Debug.Fail("Unknown OS type");
                 NativeLibraryPrefixes = Array.Empty<string>();
                 NativeLibraryExtensions = Array.Empty<string>();
+                NuGetPackagesCache = string.Empty;
             }
         }
     }

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/RuntimeConfig.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/RuntimeConfig.cs
@@ -1,0 +1,8 @@
+// https://github.com/natemcmaster/DotNetCorePlugins/blob/406c9b2ac18167e3ecac4a91ff14d7f12a79f0f3/src/Plugins/Internal/RuntimeConfig.cs
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    internal class RuntimeConfig
+    {
+        public RuntimeOptions runtimeOptions { get; set; }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/RuntimeConfigExtensions.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/RuntimeConfigExtensions.cs
@@ -1,0 +1,132 @@
+// Based on https://github.com/natemcmaster/DotNetCorePlugins/blob/406c9b2ac18167e3ecac4a91ff14d7f12a79f0f3/src/Plugins/Loader/RuntimeConfigExtensions.cs
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    /// <summary>
+    /// Extensions for creating a load context using settings from a runtimeconfig.json file
+    /// </summary>
+    public static class RuntimeConfigExtensions
+    {
+        private const string JsonExt = ".json";
+
+        /// <summary>
+        /// Tries to get additional probing paths using settings found in the runtimeconfig.json and runtimeconfig.dev.json files.
+        /// </summary>
+        /// <param name="runtimeConfigPath">The path to the runtimeconfig.json file</param>
+        /// <param name="isDevelopmentEnvironment">If it is development environment, should be true. Will add configs local probing paths in that case.</param>
+        /// <param name="error">The error, if one occurs while parsing runtimeconfig.json</param>
+        /// <returns>Additional probing paths (including NuGet and DotNet package caches).</returns>
+        public static IEnumerable<string> TryGetAdditionalProbingPathFromRuntimeConfig(
+            this string runtimeConfigPath,
+            bool isDevelopmentEnvironment,
+            out Exception error)
+        {
+            // Add NuGet cache path always
+            var result = new HashSet<string>() { PlatformInformation.NuGetPackagesCache };
+            error = null;
+            try
+            {
+                var config = TryReadConfig(runtimeConfigPath);
+                if (config == null)
+                {
+                    return result;
+                }
+
+                var configDevPath = runtimeConfigPath.Substring(0, runtimeConfigPath.Length - JsonExt.Length) + ".dev.json";
+                var devConfig = TryReadConfig(configDevPath);
+
+                var tfm = config.runtimeOptions?.Tfm ?? devConfig?.runtimeOptions?.Tfm;
+
+                if (isDevelopmentEnvironment && config.runtimeOptions != null)
+                {
+                    result.UnionWith(ExtractProbingPaths(config.runtimeOptions, tfm));
+                }
+
+                if (isDevelopmentEnvironment && devConfig?.runtimeOptions != null)
+                {
+                    result.UnionWith(ExtractProbingPaths(devConfig.runtimeOptions, tfm));
+                }
+
+                // Add dotnet store path
+                if (tfm != null)
+                {
+                    var dotnet = Process.GetCurrentProcess().MainModule.FileName;
+                    if (string.Equals(Path.GetFileNameWithoutExtension(dotnet), "dotnet", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var dotnetHome = Path.GetDirectoryName(dotnet);
+                        result.Add(Path.Combine(dotnetHome, "store", RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(), tfm));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+            return result;
+        }
+
+        private static IEnumerable<string> ExtractProbingPaths(RuntimeOptions options, string tfm)
+        {
+            var result = new List<string>();
+            if (options.AdditionalProbingPaths == null)
+            {
+                return result;
+            }
+
+            foreach (var item in options.AdditionalProbingPaths)
+            {
+                var path = item;
+                if (path.Contains("|arch|"))
+                {
+                    path = path.Replace("|arch|", RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant());
+                }
+
+                if (path.Contains("|tfm|"))
+                {
+                    if (tfm == null)
+                    {
+                        // We don't have enough information to parse this
+                        continue;
+                    }
+
+                    path = path.Replace("|tfm|", tfm);
+                }
+
+                result.Add(path);
+            }
+            return result;
+        }
+
+        private static RuntimeConfig TryReadConfig(string path)
+        {
+            try
+            {
+                using (var file = File.OpenText(path))
+                using (var json = new JsonTextReader(file))
+                {
+                    var serializer = new JsonSerializer
+                    {
+                        ContractResolver = new DefaultContractResolver
+                        {
+                            NamingStrategy = new CamelCaseNamingStrategy(),
+                        },
+                    };
+                    return serializer.Deserialize<RuntimeConfig>(json);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}
+

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/RuntimeOptions.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/RuntimeOptions.cs
@@ -1,0 +1,10 @@
+// https://github.com/natemcmaster/DotNetCorePlugins/blob/406c9b2ac18167e3ecac4a91ff14d7f12a79f0f3/src/Plugins/Internal/RuntimeOptions.cs
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    internal class RuntimeOptions
+    {
+        public string Tfm { get; set; }
+
+        public string[] AdditionalProbingPaths { get; set; }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/AssemblyLoading/TPA.cs
+++ b/VirtoCommerce.Platform.Modules/AssemblyLoading/TPA.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace VirtoCommerce.Platform.Modules.AssemblyLoading
+{
+    [SuppressMessage("SonarLint", "S101", Justification = "TPA is common abbreviation for Trusted Platform Assemblies, not need to change to Pascal Case.")]
+    internal static class TPA
+    {
+        private static readonly string[] _TPAPaths = GetTPAList();
+
+        static TPA()
+        {
+        }
+
+        /// <summary>
+        /// Gets the list of Trusted Platform Assemblies (TPA).
+        /// <para>
+        /// https://github.com/dotnet/coreclr/issues/919#issuecomment-285928695
+        /// https://docs.microsoft.com/en-US/dotnet/core/tutorials/netcore-hosting#step-5---preparing-appdomain-settings
+        /// </para>
+        /// </summary>
+        /// <returns>Returns the list of TPA paths.</returns>
+        static string[] GetTPAList()
+        {
+            var tpa = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+            return tpa.Split(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ";" : ":");
+        }
+
+        /// <summary>
+        /// Checks whether we have assembly with the same file name in TPA list.
+        /// </summary>
+        /// <param name="assemblyFileName">File name with extension and without path.</param>
+        /// <returns>True if TPA list contains assembly with the same file name, otherwise false.</returns>
+        public static bool ContainsAssembly(string assemblyFileName)
+        {
+            return _TPAPaths.Any(x => x.EndsWith(Path.DirectorySeparatorChar + assemblyFileName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/VirtoCommerce.Platform.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/VirtoCommerce.Platform.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Modules.External;
 
@@ -13,7 +15,9 @@ namespace VirtoCommerce.Platform.Modules
             services.AddSingleton(services);
 
             services.AddSingleton<IModuleInitializer, ModuleInitializer>();
-            services.AddSingleton<IAssemblyResolver, LoadContextAssemblyResolver>();
+            // Cannot inject IHostingEnvironment to LoadContextAssemblyResolver as IsDevelopment() is an extension method (means static) and cannot be mocked by Moq in tests
+            services.AddSingleton<IAssemblyResolver, LoadContextAssemblyResolver>(provider =>
+                new LoadContextAssemblyResolver(provider.GetService<ILogger<LoadContextAssemblyResolver>>(), provider.GetService<IHostingEnvironment>().IsDevelopment()));
             services.AddSingleton<IModuleManager, ModuleManager>();
             services.AddSingleton<ILocalModuleCatalog, LocalStorageModuleCatalog>();
             services.AddSingleton<IModuleCatalog>(provider => provider.GetService<ILocalModuleCatalog>());

--- a/VirtoCommerce.Platform.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/VirtoCommerce.Platform.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -17,7 +17,6 @@ namespace VirtoCommerce.Platform.Modules
             services.AddSingleton<IModuleManager, ModuleManager>();
             services.AddSingleton<ILocalModuleCatalog, LocalStorageModuleCatalog>();
             services.AddSingleton<IModuleCatalog>(provider => provider.GetService<ILocalModuleCatalog>());
-            services.AddSingleton<IAssemblyResolver, LoadContextAssemblyResolver>();
 
             if (setupAction != null)
             {

--- a/VirtoCommerce.Platform.Modules/LoadContextAssemblyResolver.cs
+++ b/VirtoCommerce.Platform.Modules/LoadContextAssemblyResolver.cs
@@ -3,49 +3,41 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
-using McMaster.NETCore.Plugins;
-using Microsoft.Extensions.DependencyModel;
-using Microsoft.Extensions.DependencyModel.Resolution;
 using Microsoft.Extensions.Logging;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
+using VirtoCommerce.Platform.Core.Modularity.Exceptions;
+using VirtoCommerce.Platform.Modules.AssemblyLoading;
+
 namespace VirtoCommerce.Platform.Modules
 {
 
     public class LoadContextAssemblyResolver : IAssemblyResolver
     {
         private readonly ILogger<LoadContextAssemblyResolver> _logger;
-        private readonly static string[] _possibleDependencyExtensions = new[]
-        {
-            //Windows
-            ".dll",
-            ".ni.dll",
-            ".exe",
-            ".ni.exe",
-            //Unix
-            ".so",
-            ".ni.so",
-            //MacOS
-            ".dylib",
-            ".ni.dylib",
-        };
+        private readonly Dictionary<string, Assembly> _loadedAssemblies = new Dictionary<string, Assembly>();
+        private string _basePath;
+        private readonly HashSet<string> _additionalProbingPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly string[] _TPAPaths = GetTPAList();
+
         public LoadContextAssemblyResolver(ILogger<LoadContextAssemblyResolver> logger)
         {
             _logger = logger;
         }
 
         /// <summary>
-        /// Registers the specified assembly and resolves the types in it when the AppDomain requests for it.
+        /// Loads specified assembly and all its nested dependencies to default AssemblyLoadContext (ALC).
         /// </summary>
-        /// <param name="assemblyFilePath">The path to the assembly to load in the LoadFrom context.</param>    
-        public Assembly LoadAssemblyFrom(string assemblyFilePath)
+        /// <param name="assemblyPath">The path to the assembly to load.</param>
+        /// <exception cref="ModuleInitializeException">If cannot load assembly or its dependencies.</exception>
+        public Assembly LoadAssemblyFrom(string assemblyPath)
         {
-            Uri assemblyUri = GetFileUri(assemblyFilePath);
+            var assemblyUri = GetFileUri(assemblyPath);
 
             if (assemblyUri == null)
             {
-                throw new ArgumentException("The argument must be a valid absolute Uri to an assembly file.", nameof(assemblyFilePath));
+                throw new ArgumentException("The argument must be a valid absolute Uri to an assembly file.", nameof(assemblyPath));
             }
 
             if (!File.Exists(assemblyUri.LocalPath))
@@ -53,89 +45,164 @@ namespace VirtoCommerce.Platform.Modules
                 throw new FileNotFoundException(assemblyUri.LocalPath);
             }
 
-            var loader = PluginLoader.CreateFromAssemblyFile(assemblyUri.LocalPath, PluginLoaderOptions.None);
-            var assembly = loader.LoadDefaultAssembly();
+            // Fill _basePath and _additionalProbingPaths based on assemblyPath
+            // In fact we could add some _additionalProbingPaths to support assembly storages like NuGet package cache (), if we would need
+            var assemblyDirectory = Path.GetDirectoryName(assemblyUri.LocalPath);
+            _basePath = assemblyDirectory;
+            if (!_additionalProbingPaths.Contains(assemblyDirectory))
+            {
+                _additionalProbingPaths.Add(assemblyDirectory);
+            }
 
-            //var assembly = LoadWithAllReferencedAssebliesRecursive(assemblyUri.LocalPath);
+            var assembly = LoadAssemblyWithReferences(assemblyUri.LocalPath);
             return assembly;
         }
 
-        private Assembly LoadWithAllReferencedAssebliesRecursive(string assemblyPath)
+        private Assembly LoadAssemblyWithReferences(string assemblyPath)
         {
-            Assembly assembly = null;
+            var depsFilePath = Path.ChangeExtension(assemblyPath, ".deps.json");
 
-            if (File.Exists(assemblyPath))
+            if (!File.Exists(depsFilePath))
             {
-                // assembly = new AssemblyResolver(assemblyPath, _logger).Assembly;
-                assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-                var dependencyContext = DependencyContext.Load(assembly);
-
-                var assemblyResolver = new CompositeCompilationAssemblyResolver
-                                        (new ICompilationAssemblyResolver[]
-                {
-                        new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(assemblyPath) + "\\"),
-                        new ReferenceAssemblyPathResolver(),
-                        new PackageCompilationAssemblyResolver()
-                });
-                var loadContext = AssemblyLoadContext.GetLoadContext(assembly);
-
-                //These event handler required for load modules dependencies (packages and libraries). It is the best solution what I've found.
-                //https://www.codeproject.com/Articles/1194332/Resolving-Assemblies-in-NET-Core
-                //https://github.com/dotnet/corefx/issues/11639
-                //https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/assemblyloadcontext.md
-                //https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/corehost.md
-                loadContext.Resolving += (context, assemblyName) =>
-                {
-                    bool assemblyPredicate(RuntimeLibrary runtime)
-                    {
-                        var possibleDendencencyNames = _possibleDependencyExtensions.Select(ext => $"{assemblyName.Name}{ext}");
-                        var result = runtime.Name.EqualsInvariant(assemblyName.Name) || runtime.RuntimeAssemblyGroups.Any(g => g.AssetPaths.Any(ap => possibleDendencencyNames.Any(n => ap.EndsWith(n, StringComparison.OrdinalIgnoreCase))));
-                        if (result)
-                        {
-                            //Need to do an additional comparison by version because modules can use different versions
-                            if (Version.TryParse(runtime.Version, out var version))
-                            {
-                                result = new SemanticVersion(assemblyName.Version).IsCompatibleWith(new SemanticVersion(version));
-                            }
-                        }
-                        return result;
-                    }
-                    _logger.LogDebug($"Trying to resolve {assemblyName} in the {assembly.GetName().Name} dependencies");
-
-                    //TODO: The current dependency resolving approach tries find dependency only within the direct dependencies of the main modules libraries that usually have Web suffix in name, 
-                    // therefore  if any of these libraries doesn't have the searched  dependency then dependency won't be resolved.
-                    //E.g  Module.Data has the Dep1 nuget library as direct dependency but Module.Data.Web doesn't in result  the  Dep1 won't be resolved.
-                    var library = dependencyContext.RuntimeLibraries.FirstOrDefault(assemblyPredicate);
-
-                    if (library != null)
-                    {
-                        var wrapper = new CompilationLibrary(
-                            library.Type,
-                            library.Name,
-                            library.Version,
-                            library.Hash,
-                            library.RuntimeAssemblyGroups.SelectMany(g => g.AssetPaths),
-                            library.Dependencies,
-                            library.Serviceable);
-
-                        var assemblies = new List<string>();
-                        assemblyResolver.TryResolveAssemblyPaths(wrapper, assemblies);
-                        if (assemblies.Count > 0)
-                        {
-                            _logger.LogDebug($"Load assembly {assemblyName} from {assemblies[0]}");
-
-                            return context.LoadFromAssemblyPath(assemblies[0]);
-                        }
-                    }
-                    return null;
-                };
+                throw new ModuleInitializeException($"Cannot find \".deps.json\" file for \"{assemblyPath}\".");
             }
-            return assembly;
+
+            var mainAssemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
+            Assembly mainAssembly = null;
+
+            // Load all assembly referencies which we could get through .deps.json file
+            foreach (var dependency in DependencyReader.ExtractDependencies(depsFilePath))
+            {
+                try
+                {
+                    var loadedAssembly = LoadAssemblyCached(dependency) ?? throw GenerateAssemblyLoadException(dependency.Name.Name, assemblyPath);
+                    if (mainAssemblyName.Equals(loadedAssembly.GetName().Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        mainAssembly = loadedAssembly;
+                    }
+                }
+                catch (Exception ex) when (!(ex is ModuleInitializeException))
+                {
+                    throw GenerateAssemblyLoadException(dependency.Name.Name, assemblyPath, ex);
+                }
+
+            }
+
+            return mainAssembly;
+        }
+
+        /// <summary>
+        /// Gets the list of Trusted Platform Assemblies (TPA).
+        /// <para>
+        /// https://github.com/dotnet/coreclr/issues/919#issuecomment-285928695
+        /// https://docs.microsoft.com/en-US/dotnet/core/tutorials/netcore-hosting#step-5---preparing-appdomain-settings
+        /// </para>
+        /// </summary>
+        /// <returns>Returns the list of TPA paths.</returns>
+        private static string[] GetTPAList()
+        {
+            var tpa = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+            return tpa.Split(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ";" : ":");
+        }
+
+        private ModuleInitializeException GenerateAssemblyLoadException(string assemblyPath, string modulePath, Exception innerException = null)
+        {
+            return new ModuleInitializeException($"Cannot load \"{assemblyPath}\" for module \"{modulePath}\".", innerException);
+        }
+
+        /// <summary>
+        /// Loads assembly to AssemblyLoadContext.Default or gets it from own assembly cache.
+        /// <para>
+        /// Note that only one version of assembly would be loaded and cached by AssemblyName.Name, for all other versions returns cached assembly.
+        /// </para>
+        /// </summary>
+        /// <param name="managedLibrary">ManagedLibrary object containing library name and paths.</param>
+        /// <returns>Retures loaded assembly (could be cached).</returns>
+        private Assembly LoadAssemblyCached(ManagedLibrary managedLibrary)
+        {
+            var assemblyName = managedLibrary.Name;
+            if (_loadedAssemblies.ContainsKey(assemblyName.Name))
+            {
+                return _loadedAssemblies[assemblyName.Name];
+            }
+
+            var loadedAssembly = LoadAssemblyInternal(managedLibrary);
+            if (loadedAssembly != null)
+            {
+                _loadedAssemblies.Add(assemblyName.Name, loadedAssembly);
+            }
+            return loadedAssembly;
+        }
+
+        /// <summary>
+        /// Performs loading into AssemblyLoadContext.Default using LoadFromAssemblyName for TPA assemblies and LoadFromAssemblyPath for other dependecies.
+        /// <para>
+        /// Based on https://github.com/natemcmaster/DotNetCorePlugins/blob/8f5c28fa70f0869a1af2e2904536268f184e71de/src/Plugins/Loader/ManagedLoadContext.cs Load method,
+        /// but avoided FileNotFoundException from LoadFromAssemblyName trying only load TPA assemblies that way.
+        /// </para>
+        /// </summary>
+        /// <param name="managedLibrary">ManagedLibrary object containing assembly name and paths.</param>
+        /// <returns>Returns loaded assembly.</returns>
+        private Assembly LoadAssemblyInternal(ManagedLibrary managedLibrary)
+        {
+            // To avoid FileNotFoundException for assemblies that are included in TPA - we load them using AssemblyLoadContext.Default.LoadFromAssemblyName.
+            var assemblyFileName = Path.GetFileName(managedLibrary.AppLocalPath);
+            if (_TPAPaths.Any(x => x.EndsWith(Path.DirectorySeparatorChar + assemblyFileName, StringComparison.OrdinalIgnoreCase)))
+            {
+                var defaultAssembly = AssemblyLoadContext.Default.LoadFromAssemblyName(managedLibrary.Name);
+                if (defaultAssembly != null)
+                {
+                    return defaultAssembly;
+                }
+            }
+
+            if (SearchForLibrary(managedLibrary, out var path))
+            {
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+            }
+
+            return null;
+        }
+
+        private bool SearchForLibrary(ManagedLibrary library, out string path)
+        {
+            // 1. Check for in _basePath + app local path
+            var localFile = Path.Combine(_basePath, library.AppLocalPath);
+            if (File.Exists(localFile))
+            {
+                path = localFile;
+                return true;
+            }
+
+            // 2. Search additional probing paths
+            foreach (var searchPath in _additionalProbingPaths)
+            {
+                var candidate = Path.Combine(searchPath, library.AdditionalProbingPath);
+                if (File.Exists(candidate))
+                {
+                    path = candidate;
+                    return true;
+                }
+            }
+
+            // 3. Search in base path
+            foreach (var ext in PlatformInformation.ManagedAssemblyExtensions)
+            {
+                var local = Path.Combine(_basePath, library.Name.Name + ext);
+                if (File.Exists(local))
+                {
+                    path = local;
+                    return true;
+                }
+            }
+
+            path = null;
+            return false;
         }
 
         private static Uri GetFileUri(string filePath)
         {
-            if (String.IsNullOrEmpty(filePath))
+            if (string.IsNullOrEmpty(filePath))
             {
                 return null;
             }
@@ -153,5 +220,4 @@ namespace VirtoCommerce.Platform.Modules
             return uri;
         }
     }
-
 }

--- a/VirtoCommerce.Platform.Modules/Local/LocalStorageModuleCatalog.cs
+++ b/VirtoCommerce.Platform.Modules/Local/LocalStorageModuleCatalog.cs
@@ -32,8 +32,8 @@ namespace VirtoCommerce.Platform.Modules
                 Directory.CreateDirectory(_options.ProbingPath);
             }
 
-            if (!discoveryPath.EndsWith("\\", StringComparison.OrdinalIgnoreCase))
-                discoveryPath += "\\";
+            if (!discoveryPath.EndsWith(Path.DirectorySeparatorChar))
+                discoveryPath += Path.DirectorySeparatorChar;
 
             var rootUri = new Uri(discoveryPath);
 

--- a/VirtoCommerce.Platform.Modules/ModuleInitializer.cs
+++ b/VirtoCommerce.Platform.Modules/ModuleInitializer.cs
@@ -124,7 +124,7 @@ namespace VirtoCommerce.Platform.Modules
                 throw new ArgumentNullException("moduleInfo");
 
             IModule result = null;
-            var moduleInitializerType = moduleInfo.Assembly.GetTypes().Where(x => typeof(IModule).IsAssignableFrom(x)).FirstOrDefault();
+            var moduleInitializerType = moduleInfo.Assembly.GetTypes().FirstOrDefault(x => typeof(IModule).IsAssignableFrom(x));
             if (moduleInitializerType != null && moduleInitializerType != typeof(IModule))
             {
                 result = (IModule)Activator.CreateInstance(moduleInitializerType);

--- a/VirtoCommerce.Platform.Modules/ModuleManager.cs
+++ b/VirtoCommerce.Platform.Modules/ModuleManager.cs
@@ -144,7 +144,14 @@ namespace VirtoCommerce.Platform.Modules
         protected virtual bool ModuleNeedsRetrieval(ModuleInfo moduleInfo)
         {
             if (moduleInfo == null)
+            {
                 throw new ArgumentNullException("moduleInfo");
+            }
+
+            if (moduleInfo.Assembly == null)
+            {
+                return true;
+            }
 
             if (moduleInfo.State == ModuleState.NotStarted)
             {

--- a/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
+++ b/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="McMaster.NETCore.Plugins" Version="0.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />

--- a/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
+++ b/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.NETCore.Plugins" Version="0.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />

--- a/VirtoCommerce.Platform.Web/Controllers/Api/ModulesController.cs
+++ b/VirtoCommerce.Platform.Web/Controllers/Api/ModulesController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
@@ -35,8 +36,9 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         private readonly ExternalModuleCatalogOptions _externalModuleCatalogOptions;
         private static readonly object _lockObject = new object();
         private static readonly FormOptions _defaultFormOptions = new FormOptions();
+        private readonly IApplicationLifetime _applicationLifetime;
 
-        public ModulesController(IExternalModuleCatalog externalModuleCatalog, IModuleInstaller moduleInstaller, IPushNotificationManager pushNotifier, IUserNameResolver userNameResolver, ISettingsManager settingsManager, IOptions<PlatformOptions> platformOptions, IOptions<ExternalModuleCatalogOptions> externalModuleCatalogOptions)
+        public ModulesController(IExternalModuleCatalog externalModuleCatalog, IModuleInstaller moduleInstaller, IPushNotificationManager pushNotifier, IUserNameResolver userNameResolver, ISettingsManager settingsManager, IOptions<PlatformOptions> platformOptions, IOptions<ExternalModuleCatalogOptions> externalModuleCatalogOptions, IApplicationLifetime applicationLifetime)
         {
             _externalModuleCatalog = externalModuleCatalog;
             _moduleInstaller = moduleInstaller;
@@ -45,6 +47,7 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             _settingsManager = settingsManager;
             _platformOptions = platformOptions.Value;
             _externalModuleCatalogOptions = externalModuleCatalogOptions.Value;
+            _applicationLifetime = applicationLifetime;
         }
 
         /// <summary>
@@ -252,8 +255,8 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         [Authorize(PlatformConstants.Security.Permissions.ModuleManage)]
         public ActionResult Restart()
         {
-            //TODO:
-            throw new NotImplementedException();
+            _applicationLifetime.StopApplication();
+            return NoContent();
         }
 
         /// <summary>

--- a/VirtoCommerce.Platform.sln
+++ b/VirtoCommerce.Platform.sln
@@ -155,13 +155,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{C131
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "vc-module-sitemaps", "vc-module-sitemaps", "{A40AF96F-91B2-4A92-8465-A3B5D7060773}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.SitemapsModule.Core", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj", "{E135BDC2-6425-4A9B-A287-04D0EA08D56D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SitemapsModule.Core", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Core\VirtoCommerce.SitemapsModule.Core.csproj", "{E135BDC2-6425-4A9B-A287-04D0EA08D56D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.SitemapsModule.Data", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj", "{2D6E6B32-70F8-4D3B-899B-53C3733B1876}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SitemapsModule.Data", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Data\VirtoCommerce.SitemapsModule.Data.csproj", "{2D6E6B32-70F8-4D3B-899B-53C3733B1876}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.SitemapsModule.Test", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Test\VirtoCommerce.SitemapsModule.Test.csproj", "{D892E414-8844-48C0-86EF-1DD3D7CCD5AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SitemapsModule.Test", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Test\VirtoCommerce.SitemapsModule.Test.csproj", "{D892E414-8844-48C0-86EF-1DD3D7CCD5AC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.SitemapsModule.Web", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Web\VirtoCommerce.SitemapsModule.Web.csproj", "{672C0CF9-3991-4B2C-87EF-84E5042D3698}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SitemapsModule.Web", "Modules\vc-module-sitemaps\VirtoCommerce.SitemapsModule.Web\VirtoCommerce.SitemapsModule.Web.csproj", "{672C0CF9-3991-4B2C-87EF-84E5042D3698}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "vc-module-subscriptions", "vc-module-subscriptions", "{B80ACEF3-FCE2-4D61-BDF6-041ACAB7DBA0}"
 EndProject
@@ -171,13 +171,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SubscriptionM
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SubscriptionModule.Web", "Modules\vc-module-subscriptions\VirtoCommerce.SubscriptionModule.Web\VirtoCommerce.SubscriptionModule.Web.csproj", "{B5CFF5D8-EB98-478B-8471-9ED2F50C1167}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.SubscriptionModule.Test", "Modules\vc-module-subscriptions\VirtoCommerce.SubscriptionModule.Test\VirtoCommerce.SubscriptionModule.Test.csproj", "{A3C4668C-B7F1-42CA-9C9A-0357C2BC6667}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.SubscriptionModule.Test", "Modules\vc-module-subscriptions\VirtoCommerce.SubscriptionModule.Test\VirtoCommerce.SubscriptionModule.Test.csproj", "{A3C4668C-B7F1-42CA-9C9A-0357C2BC6667}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.CustomerSampleModule.Web", "Modules\vc-module-customer\samples\VirtoCommerce.CustomerSampleModule.Web\VirtoCommerce.CustomerSampleModule.Web.csproj", "{847619DC-87F9-451A-BBB3-FDD167DB66E6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{CB3E4574-7FA0-4040-B29F-B2347A1D2A9C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtoCommerce.OrdersModule2.Web", "Modules\vc-module-orders\samples\VirtoCommerce.OrdersModule2.Web\VirtoCommerce.OrdersModule2.Web.csproj", "{DE1FC248-1465-417D-BF9A-83382C89D712}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Module1.Test", "Modules\Module1\Module1.Test\Module1.Test.csproj", "{21C3CD47-5E04-4E1A-9483-87B8B3683CF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -425,14 +427,6 @@ Global
 		{E83208F9-9C35-43E5-992B-12438E863F3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E83208F9-9C35-43E5-992B-12438E863F3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E83208F9-9C35-43E5-992B-12438E863F3C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DE1FC248-1465-417D-BF9A-83382C89D712}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DE1FC248-1465-417D-BF9A-83382C89D712}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DE1FC248-1465-417D-BF9A-83382C89D712}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DE1FC248-1465-417D-BF9A-83382C89D712}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E135BDC2-6425-4A9B-A287-04D0EA08D56D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E135BDC2-6425-4A9B-A287-04D0EA08D56D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E135BDC2-6425-4A9B-A287-04D0EA08D56D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -465,6 +459,18 @@ Global
 		{A3C4668C-B7F1-42CA-9C9A-0357C2BC6667}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3C4668C-B7F1-42CA-9C9A-0357C2BC6667}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3C4668C-B7F1-42CA-9C9A-0357C2BC6667}.Release|Any CPU.Build.0 = Release|Any CPU
+		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{847619DC-87F9-451A-BBB3-FDD167DB66E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE1FC248-1465-417D-BF9A-83382C89D712}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE1FC248-1465-417D-BF9A-83382C89D712}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE1FC248-1465-417D-BF9A-83382C89D712}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE1FC248-1465-417D-BF9A-83382C89D712}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21C3CD47-5E04-4E1A-9483-87B8B3683CF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21C3CD47-5E04-4E1A-9483-87B8B3683CF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21C3CD47-5E04-4E1A-9483-87B8B3683CF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21C3CD47-5E04-4E1A-9483-87B8B3683CF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -536,9 +542,6 @@ Global
 		{100F5DBF-CEE7-4764-A8C6-95484D0BC6FD} = {BE0C4BE9-8E9F-4317-869D-659D7CBC9076}
 		{E83208F9-9C35-43E5-992B-12438E863F3C} = {BE0C4BE9-8E9F-4317-869D-659D7CBC9076}
 		{C131F427-297E-43F8-861F-43702FFD2674} = {B70175BB-3753-44A7-BBC6-A7A8A8BC0E22}
-		{847619DC-87F9-451A-BBB3-FDD167DB66E6} = {C131F427-297E-43F8-861F-43702FFD2674}
-		{CB3E4574-7FA0-4040-B29F-B2347A1D2A9C} = {BE0C4BE9-8E9F-4317-869D-659D7CBC9076}
-		{DE1FC248-1465-417D-BF9A-83382C89D712} = {CB3E4574-7FA0-4040-B29F-B2347A1D2A9C}
 		{A40AF96F-91B2-4A92-8465-A3B5D7060773} = {7052A390-9A84-46DA-BD3B-556FD74DEC97}
 		{E135BDC2-6425-4A9B-A287-04D0EA08D56D} = {A40AF96F-91B2-4A92-8465-A3B5D7060773}
 		{2D6E6B32-70F8-4D3B-899B-53C3733B1876} = {A40AF96F-91B2-4A92-8465-A3B5D7060773}
@@ -549,6 +552,10 @@ Global
 		{61230D9E-173B-4949-ACA8-83B4238A34E1} = {B80ACEF3-FCE2-4D61-BDF6-041ACAB7DBA0}
 		{B5CFF5D8-EB98-478B-8471-9ED2F50C1167} = {B80ACEF3-FCE2-4D61-BDF6-041ACAB7DBA0}
 		{A3C4668C-B7F1-42CA-9C9A-0357C2BC6667} = {B80ACEF3-FCE2-4D61-BDF6-041ACAB7DBA0}
+		{847619DC-87F9-451A-BBB3-FDD167DB66E6} = {C131F427-297E-43F8-861F-43702FFD2674}
+		{CB3E4574-7FA0-4040-B29F-B2347A1D2A9C} = {BE0C4BE9-8E9F-4317-869D-659D7CBC9076}
+		{DE1FC248-1465-417D-BF9A-83382C89D712} = {CB3E4574-7FA0-4040-B29F-B2347A1D2A9C}
+		{21C3CD47-5E04-4E1A-9483-87B8B3683CF8} = {1B8260F3-4F5D-4046-9AE0-34F2F9320409}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {80F99D88-A3B2-4ED2-9148-43D43EBFFFC3}


### PR DESCRIPTION
- Added test for nested module dependencies loading;
- Reworked LoadContextAssemblyResolver assembly loading: every module assembly with all level dependencies is loaded into AssemblyLoadContext.Default to allow shared types to be used;
- Set all module Web projects <CopyLocalLockFileAssemblies> option to true to have the possibility to copy all dependencies from its bin folder (using this approach it should work on prod env where we cannot just restore packages). Futher investigation and revision could be done based on:
dotnet/cli#10502;
- Set <RuntimeIdentifier>win10-x64</RuntimeIdentifier> option to VirtoCommerce.ImageToolsModule.Web project to address problem with NuGet package Microsoft.Windows.Compatibility, which do not copy  its dependency "System.Private.ServiceModel.dll" on publishing. Explicit reference to System.ServiceModel.Http 4.5.3 package did not help, setting RID helped, though it makes module platform dependent. Info:
dotnet/wcf#2349, https://stackoverflow.com/questions/50746592/system-private-servicemodel-missing-in-azure-app-service-at-runtime;
- Removed redundant LoadContextAssemblyResolver singleton registration;
- Changed Windows specific "\" path separator to platform independent Path.DirectorySeparatorChar in LocalStorageModuleCatalog probing folder;
- Excluded copying assembly related dlls that are in TPA;
- Splitted assembly file extensions (dll, exe) and assembly service file extensions (pdb, xml, .deps.json) for using in filtering;
- Fixed couple of Sonar warnings;