### PR TITLE
Copy the item id for the category item link to allow item removal.

### DIFF
--- a/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Data/Model/CategoryItemRelationEntity.cs
+++ b/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Data/Model/CategoryItemRelationEntity.cs
@@ -26,6 +26,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             if (link == null)
                 throw new ArgumentNullException(nameof(link));
 
+            link.ListEntryId = ItemId;
             link.CategoryId = CategoryId;
             link.CatalogId = CatalogId;
             link.Priority = Priority;
@@ -38,6 +39,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             if (link == null)
                 throw new ArgumentNullException(nameof(link));
 
+            ItemId = link.ListEntryId;
             CategoryId = link.CategoryId;
             CatalogId = link.CatalogId;
             Priority = link.Priority;


### PR DESCRIPTION
Without the ItemId/ListEntryId on the model, the attempt to remove the link from the catalog item entry fails to match the item.  To reproduce, map a Catalog Product into a virtual catalog and then select and delete the link.