### PR TITLE
Create links in BulkCreateLinks.

### DIFF
--- a/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/Modules/vc-module-catalog/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -162,6 +162,17 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
                     return Unauthorized();
                 }
 
+                //create the catalog item links
+                foreach (CatalogProduct catalogProduct in hasLinkEntries)
+                {
+                    catalogProduct.Links.Add(new CategoryLink
+                    {
+                        ListEntryId = catalogProduct.Id,
+                        CategoryId = creationRequest.CategoryId,
+                        CatalogId = creationRequest.CatalogId
+                    });
+                }
+
                 if (haveProducts)
                 {
                     await SaveListCatalogEntitiesAsync(hasLinkEntries.ToArray());


### PR DESCRIPTION
Fix the CatalogModuleListEntryController BulkCreateLinks to create the product links based on the creation request.  Issue reproduced while mapping a Catalog Product into a virtual catalog that contained associations.  Other bulk add attempts failed as well without this fix.