### PR TITLE
VP-253: Reworked ExportedTypeDefinition registration

### DIFF
--- a/Modules/vc-module-export/VirtoCommerce.ExportModule.Core/Model/ExportedTypeDefinition.cs
+++ b/Modules/vc-module-export/VirtoCommerce.ExportModule.Core/Model/ExportedTypeDefinition.cs
@@ -10,42 +10,18 @@ namespace VirtoCommerce.ExportModule.Core.Model
 
         public string Group { get; set; }
 
-        public ExportedTypeMetadata MetaData { get; protected set; }
+        public ExportedTypeMetadata MetaData { get; set; }
 
-        public ExportedTypeMetadata TabularMetaData { get; protected set; }
+        public ExportedTypeMetadata TabularMetaData { get; set; }
 
         public string ExportDataQueryType { get; set; }
 
         public bool IsTabularExportSupported { get => TabularDataConverter != null; }
 
         [JsonIgnore]
-        public ITabularDataConverter TabularDataConverter { get; protected set; }
+        public ITabularDataConverter TabularDataConverter { get; set; }
 
         [JsonIgnore]
-        public Func<ExportDataQuery, IPagedDataSource> ExportedDataSourceFactory { get; protected set; }
-
-        public ExportedTypeDefinition WithDataSourceFactory(Func<ExportDataQuery, IPagedDataSource> factory)
-        {
-            ExportedDataSourceFactory = factory;
-            return this;
-        }
-
-        public ExportedTypeDefinition WithMetadata(ExportedTypeMetadata metadata)
-        {
-            MetaData = metadata;
-            return this;
-        }
-
-        public ExportedTypeDefinition WithTabularMetadata(ExportedTypeMetadata tabularMetadata)
-        {
-            TabularMetaData = tabularMetadata;
-            return this;
-        }
-
-        public ExportedTypeDefinition WithTabularDataConverter(ITabularDataConverter tabularDataConverter)
-        {
-            TabularDataConverter = tabularDataConverter;
-            return this;
-        }
+        public Func<ExportDataQuery, IPagedDataSource> ExportedDataSourceFactory { get; set; }
     }
 }

--- a/Modules/vc-module-export/VirtoCommerce.ExportModule.Core/Services/IKnownExportTypesRegistrar.cs
+++ b/Modules/vc-module-export/VirtoCommerce.ExportModule.Core/Services/IKnownExportTypesRegistrar.cs
@@ -5,6 +5,6 @@ namespace VirtoCommerce.ExportModule.Core.Services
     public interface IKnownExportTypesRegistrar
     {
         ExportedTypeDefinition[] GetRegisteredTypes();
-        ExportedTypeDefinition RegisterType(string exportedTypeName, string group, string exportQueryType);
+        ExportedTypeDefinition RegisterType(ExportedTypeDefinition exportedTypeDefinition);
     }
 }

--- a/Modules/vc-module-export/VirtoCommerce.ExportModule.Data/Extensions/ExportedTypeDefinitionBuilderExtensions.cs
+++ b/Modules/vc-module-export/VirtoCommerce.ExportModule.Data/Extensions/ExportedTypeDefinitionBuilderExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using VirtoCommerce.ExportModule.Core.Model;
+using VirtoCommerce.ExportModule.Core.Services;
+using VirtoCommerce.ExportModule.Data.Services;
+
+namespace VirtoCommerce.ExportModule.Data.Extensions
+{
+    public static class ExportedTypeDefinitionBuilderExtensions
+    {
+        public static ExportedTypeDefinitionBuilder WithDataSourceFactory(this ExportedTypeDefinitionBuilder builder, Func<ExportDataQuery, IPagedDataSource> factory)
+        {
+            builder.ExportedTypeDefinition.ExportedDataSourceFactory = factory;
+            return builder;
+        }
+
+        public static ExportedTypeDefinitionBuilder WithMetadata(this ExportedTypeDefinitionBuilder builder, ExportedTypeMetadata metadata)
+        {
+            builder.ExportedTypeDefinition.MetaData = metadata;
+            return builder;
+        }
+
+        public static ExportedTypeDefinitionBuilder WithTabularMetadata(this ExportedTypeDefinitionBuilder builder, ExportedTypeMetadata tabularMetadata)
+        {
+            builder.ExportedTypeDefinition.TabularMetaData = tabularMetadata;
+            return builder;
+        }
+
+        public static ExportedTypeDefinitionBuilder WithTabularDataConverter(this ExportedTypeDefinitionBuilder builder, ITabularDataConverter tabularDataConverter)
+        {
+            builder.ExportedTypeDefinition.TabularDataConverter = tabularDataConverter;
+            return builder;
+        }
+    }
+}

--- a/Modules/vc-module-export/VirtoCommerce.ExportModule.Data/Services/ExportedTypeDefinitionBuilder.cs
+++ b/Modules/vc-module-export/VirtoCommerce.ExportModule.Data/Services/ExportedTypeDefinitionBuilder.cs
@@ -1,0 +1,33 @@
+using System;
+using VirtoCommerce.ExportModule.Core.Model;
+
+namespace VirtoCommerce.ExportModule.Data.Services
+{
+    public class ExportedTypeDefinitionBuilder
+    {
+        public ExportedTypeDefinition ExportedTypeDefinition { get; }
+
+        public ExportedTypeDefinitionBuilder(string exportedTypeName, string group, string exportQueryType)
+        {
+            ExportedTypeDefinition = new ExportedTypeDefinition()
+            {
+                TypeName = exportedTypeName,
+                Group = group,
+                ExportDataQueryType = exportQueryType,
+            };
+        }
+
+        public ExportedTypeDefinitionBuilder(ExportedTypeDefinition exportedTypeDefinition)
+        {
+            ExportedTypeDefinition = exportedTypeDefinition ?? throw new ArgumentNullException(nameof(exportedTypeDefinition));
+        }
+
+        public static ExportedTypeDefinitionBuilder Build<TExport, TDataQuery>()
+        {
+            var exportedType = typeof(TExport);
+            var dataQueryType = typeof(TDataQuery);
+
+            return new ExportedTypeDefinitionBuilder(exportedType.FullName, exportedType.Namespace, dataQueryType.Name);
+        }
+    }
+}

--- a/Modules/vc-module-export/VirtoCommerce.ExportModule.Data/Services/KnownExportTypesService.cs
+++ b/Modules/vc-module-export/VirtoCommerce.ExportModule.Data/Services/KnownExportTypesService.cs
@@ -15,19 +15,15 @@ namespace VirtoCommerce.ExportModule.Data.Services
             return _knownExportTypes.Values.ToArray();
         }
 
-        public ExportedTypeDefinition RegisterType(string exportedTypeName, string group, string exportQueryType)
+        public ExportedTypeDefinition RegisterType(ExportedTypeDefinition exportedTypeDefinition)
         {
-            if (!_knownExportTypes.TryGetValue(exportedTypeName, out var result))
+            var exportedTypeName = exportedTypeDefinition.TypeName;
+
+            if (!_knownExportTypes.ContainsKey(exportedTypeName))
             {
-                _knownExportTypes.TryAdd(exportedTypeName,
-                    new ExportedTypeDefinition()
-                    {
-                        TypeName = exportedTypeName,
-                        Group = group,
-                        ExportDataQueryType = exportQueryType,
-                    }
-                );
+                _knownExportTypes.TryAdd(exportedTypeName, exportedTypeDefinition);
             }
+
             return _knownExportTypes[exportedTypeName];
         }
 

--- a/Modules/vc-module-pricing/VirtoCommerce.PricingModule.Test/ExportImport2Test.cs
+++ b/Modules/vc-module-pricing/VirtoCommerce.PricingModule.Test/ExportImport2Test.cs
@@ -35,7 +35,6 @@ namespace VirtoCommerce.PricingModule.Test
         {
             //Arrange
             IKnownExportTypesRegistrar registrar = new KnownExportTypesService();
-            registrar.RegisterType(typeof(Price).Name, "Pricing", typeof(PriceExportDataQuery).Name);
 
             var authorizationServicesMock = AuthMockHelper.AuthServicesMock(true);
 
@@ -49,20 +48,21 @@ namespace VirtoCommerce.PricingModule.Test
             var metadata = typeof(Price).GetPropertyNames(true);
             var resolver = (IKnownExportTypesResolver)registrar;
 
-            resolver.ResolveExportedTypeDefinition(typeof(Price).Name)
+            registrar.RegisterType(ExportedTypeDefinitionBuilder.Build<Price, PriceExportDataQuery>()
                 .WithDataSourceFactory(
-                dataQuery => new PriceExportPagedDataSource(
-                    searchServiceMock.Object,
-                    priceServiceMock.Object,
-                    itemServiceMock.Object,
-                    authorizationServicesMock.AuthorizationPolicyProvider,
-                    authorizationServicesMock.AuthorizationService,
-                    authorizationServicesMock.UserClaimsPrincipalFactory,
-                    authorizationServicesMock.UserManager)
-                {
-                    DataQuery = dataQuery
-                })
-                .WithMetadata(metadata);
+                    dataQuery => new PriceExportPagedDataSource(
+                        searchServiceMock.Object,
+                        priceServiceMock.Object,
+                        itemServiceMock.Object,
+                        authorizationServicesMock.AuthorizationPolicyProvider,
+                        authorizationServicesMock.AuthorizationService,
+                        authorizationServicesMock.UserClaimsPrincipalFactory,
+                        authorizationServicesMock.UserManager)
+                    {
+                        DataQuery = dataQuery
+                    })
+                .WithMetadata(metadata)
+                .ExportedTypeDefinition);
 
             var includedColumnNames = new string[] { "Currency", "ProductId", "Sale", "List", "MinQuantity", "StartDate", "EndDate", "EffectiveValue" };
             var IncludedColumns = metadata.PropertyInfos.Where(x => includedColumnNames.Contains(x.Name, StringComparer.OrdinalIgnoreCase)).ToArray();
@@ -87,7 +87,7 @@ namespace VirtoCommerce.PricingModule.Test
                         {
                             IncludedColumns = IncludedColumns
                         },
-                        ExportTypeName = typeof(Price).Name,
+                        ExportTypeName = typeof(Price).FullName,
                         ProviderName = nameof(JsonExportProvider)
                     },
                     new Action<ExportProgressInfo>(x => Console.WriteLine(x.Description)),
@@ -117,7 +117,6 @@ namespace VirtoCommerce.PricingModule.Test
         {
             //Arrange
             IKnownExportTypesRegistrar registrar = new KnownExportTypesService();
-            registrar.RegisterType(typeof(Pricelist).Name, "Pricing", typeof(PricelistExportDataQuery).Name);
 
             var authorizationServicesMock = AuthMockHelper.AuthServicesMock(true);
 
@@ -133,19 +132,20 @@ namespace VirtoCommerce.PricingModule.Test
 
             var metadata = typeof(Pricelist).GetPropertyNames(true);
             var resolver = (IKnownExportTypesResolver)registrar;
-            resolver.ResolveExportedTypeDefinition(typeof(Pricelist).Name)
+            registrar.RegisterType(ExportedTypeDefinitionBuilder.Build<Pricelist, PricelistExportDataQuery>()
                 .WithDataSourceFactory(
-                dataQuery => new PricelistExportPagedDataSource(
-                    searchServiceMock.Object,
-                    priceServiceMock.Object,
-                    authorizationServicesMock.AuthorizationPolicyProvider,
-                    authorizationServicesMock.AuthorizationService,
-                    authorizationServicesMock.UserClaimsPrincipalFactory,
-                    authorizationServicesMock.UserManager)
-                {
-                    DataQuery = dataQuery
-                })
-                .WithMetadata(metadata);
+                    dataQuery => new PricelistExportPagedDataSource(
+                        searchServiceMock.Object,
+                        priceServiceMock.Object,
+                        authorizationServicesMock.AuthorizationPolicyProvider,
+                        authorizationServicesMock.AuthorizationService,
+                        authorizationServicesMock.UserClaimsPrincipalFactory,
+                        authorizationServicesMock.UserManager)
+                    {
+                        DataQuery = dataQuery
+                    })
+                .WithMetadata(metadata)
+                .ExportedTypeDefinition);
 
             var exportProviderFactories = new[] {
                 new Func<IExportProviderConfiguration, ExportedTypeColumnInfo[], IExportProvider>((config, includedColumns) => new JsonExportProvider(config, includedColumns)),
@@ -168,7 +168,7 @@ namespace VirtoCommerce.PricingModule.Test
                         {
                             IncludedColumns = IncludedColumns
                         },
-                        ExportTypeName = typeof(Pricelist).Name,
+                        ExportTypeName = typeof(Pricelist).FullName,
                         ProviderName = nameof(JsonExportProvider)
                     },
                     new Action<ExportProgressInfo>(x => Console.WriteLine(x.Description)),
@@ -201,7 +201,6 @@ namespace VirtoCommerce.PricingModule.Test
         {
             //Arrange
             IKnownExportTypesRegistrar registrar = new KnownExportTypesService();
-            registrar.RegisterType(typeof(Pricelist).Name, "Pricing", typeof(PricelistExportDataQuery).Name);
 
             var authorizationServicesMock = AuthMockHelper.AuthServicesMock(false);
 
@@ -217,19 +216,20 @@ namespace VirtoCommerce.PricingModule.Test
 
             var metadata = typeof(Pricelist).GetPropertyNames(true);
             var resolver = (IKnownExportTypesResolver)registrar;
-            resolver.ResolveExportedTypeDefinition(typeof(Pricelist).Name)
+            registrar.RegisterType(ExportedTypeDefinitionBuilder.Build<Pricelist, PricelistExportDataQuery>()
                 .WithDataSourceFactory(
-                dataQuery => new PricelistExportPagedDataSource(
-                    searchServiceMock.Object,
-                    priceServiceMock.Object,
-                    authorizationServicesMock.AuthorizationPolicyProvider,
-                    authorizationServicesMock.AuthorizationService,
-                    authorizationServicesMock.UserClaimsPrincipalFactory,
-                    authorizationServicesMock.UserManager)
-                {
-                    DataQuery = dataQuery
-                })
-                .WithMetadata(metadata);
+                    dataQuery => new PricelistExportPagedDataSource(
+                        searchServiceMock.Object,
+                        priceServiceMock.Object,
+                        authorizationServicesMock.AuthorizationPolicyProvider,
+                        authorizationServicesMock.AuthorizationService,
+                        authorizationServicesMock.UserClaimsPrincipalFactory,
+                        authorizationServicesMock.UserManager)
+                    {
+                        DataQuery = dataQuery
+                    })
+                .WithMetadata(metadata)
+                .ExportedTypeDefinition);
 
             var exportProviderFactories = new[] {
                 new Func<IExportProviderConfiguration, ExportedTypeColumnInfo[], IExportProvider>((config, includedColumns) => new JsonExportProvider(config, includedColumns)),
@@ -253,7 +253,7 @@ namespace VirtoCommerce.PricingModule.Test
                             {
                                 IncludedColumns = IncludedColumns
                             },
-                            ExportTypeName = typeof(Pricelist).Name,
+                            ExportTypeName = typeof(Pricelist).FullName,
                             ProviderName = nameof(JsonExportProvider)
                         },
                         new Action<ExportProgressInfo>(x => Console.WriteLine(x.Description)),
@@ -272,7 +272,6 @@ namespace VirtoCommerce.PricingModule.Test
         public Task PricelistAssignmentJsonExport()
         {
             IKnownExportTypesRegistrar registrar = new KnownExportTypesService();
-            registrar.RegisterType(typeof(PricelistAssignment).Name, "Pricing", typeof(PricelistAssignmentExportDataQuery).Name);
 
             var authorizationServicesMock = AuthMockHelper.AuthServicesMock(true);
 
@@ -284,20 +283,21 @@ namespace VirtoCommerce.PricingModule.Test
 
             var metadata = typeof(PricelistAssignment).GetPropertyNames(true);
             var resolver = (IKnownExportTypesResolver)registrar;
-            resolver.ResolveExportedTypeDefinition(typeof(PricelistAssignment).Name)
+            registrar.RegisterType(ExportedTypeDefinitionBuilder.Build<PricelistAssignment, PricelistAssignmentExportDataQuery>()
                 .WithDataSourceFactory(
-                dataQuery => new PricelistAssignmentExportPagedDataSource(
-                    searchServiceMock.Object,
-                    priceServiceMock.Object,
-                    catalogServiceMock.Object,
-                    authorizationServicesMock.AuthorizationPolicyProvider,
-                    authorizationServicesMock.AuthorizationService,
-                    authorizationServicesMock.UserClaimsPrincipalFactory,
-                    authorizationServicesMock.UserManager)
-                {
-                    DataQuery = dataQuery
-                })
-                .WithMetadata(metadata);
+                    dataQuery => new PricelistAssignmentExportPagedDataSource(
+                        searchServiceMock.Object,
+                        priceServiceMock.Object,
+                        catalogServiceMock.Object,
+                        authorizationServicesMock.AuthorizationPolicyProvider,
+                        authorizationServicesMock.AuthorizationService,
+                        authorizationServicesMock.UserClaimsPrincipalFactory,
+                        authorizationServicesMock.UserManager)
+                    {
+                        DataQuery = dataQuery
+                    })
+                .WithMetadata(metadata)
+                .ExportedTypeDefinition);
 
             var exportProviderFactories = new[] {
                 new Func<IExportProviderConfiguration, ExportedTypeColumnInfo[], IExportProvider>((config, includedColumns) => new JsonExportProvider(config, includedColumns)),
@@ -320,7 +320,7 @@ namespace VirtoCommerce.PricingModule.Test
                         {
                             IncludedColumns = IncludedColumns
                         },
-                        ExportTypeName = typeof(PricelistAssignment).Name,
+                        ExportTypeName = typeof(PricelistAssignment).FullName,
                         ProviderName = nameof(JsonExportProvider)
                     },
                     new Action<ExportProgressInfo>(x => Console.WriteLine(x.Description)),
@@ -355,7 +355,6 @@ namespace VirtoCommerce.PricingModule.Test
         public Task PriceCsvExport()
         {
             IKnownExportTypesRegistrar registrar = new KnownExportTypesService();
-            registrar.RegisterType(typeof(Price).Name, "Pricing", typeof(PriceExportDataQuery).Name);
 
             var authorizationServicesMock = AuthMockHelper.AuthServicesMock(true);
 
@@ -369,22 +368,23 @@ namespace VirtoCommerce.PricingModule.Test
             var itemServiceMock = new Mock<IItemService>();
 
             var metadata = typeof(Price).GetPropertyNames(true);
-            resolver.ResolveExportedTypeDefinition(typeof(Price).Name)
+            registrar.RegisterType(ExportedTypeDefinitionBuilder.Build<Price, PriceExportDataQuery>()
                 .WithDataSourceFactory(
-                dataQuery => new PriceExportPagedDataSource(
-                    searchServiceMock.Object,
-                    priceServiceMock.Object,
-                    itemServiceMock.Object,
-                    authorizationServicesMock.AuthorizationPolicyProvider,
-                    authorizationServicesMock.AuthorizationService,
-                    authorizationServicesMock.UserClaimsPrincipalFactory,
-                    authorizationServicesMock.UserManager)
-                {
-                    DataQuery = dataQuery
-                })
+                    dataQuery => new PriceExportPagedDataSource(
+                        searchServiceMock.Object,
+                        priceServiceMock.Object,
+                        itemServiceMock.Object,
+                        authorizationServicesMock.AuthorizationPolicyProvider,
+                        authorizationServicesMock.AuthorizationService,
+                        authorizationServicesMock.UserClaimsPrincipalFactory,
+                        authorizationServicesMock.UserManager)
+                    {
+                        DataQuery = dataQuery
+                    })
                 .WithMetadata(metadata)
                 .WithTabularDataConverter(new TabularPriceDataConverter())
-                .WithTabularMetadata(typeof(TabularPrice).GetPropertyNames(false));
+                .WithTabularMetadata(typeof(TabularPrice).GetPropertyNames(false))
+                .ExportedTypeDefinition);
 
             var exportProviderFactories = new[]
             {
@@ -408,7 +408,7 @@ namespace VirtoCommerce.PricingModule.Test
                         {
                             IncludedColumns = IncludedColumns,
                         },
-                        ExportTypeName = typeof(Price).Name,
+                        ExportTypeName = typeof(Price).FullName,
                         ProviderName = nameof(CsvExportProvider)
                     },
                     new Action<ExportProgressInfo>(x => Console.WriteLine(x.Description)),

--- a/Modules/vc-module-pricing/VirtoCommerce.PricingModule.Web/Localizations/en.VirtoCommerce.Pricing.json
+++ b/Modules/vc-module-pricing/VirtoCommerce.PricingModule.Web/Localizations/en.VirtoCommerce.Pricing.json
@@ -270,7 +270,7 @@
             }
         },
         "groups": {
-            "Pricing": {
+            "VirtoCommerce.PricingModule.Core.Model": {
                 "name": "Pricing",
                 "description": "Prices, pricelists & assignments"
             }

--- a/Modules/vc-module-pricing/VirtoCommerce.PricingModule.Web/Module.cs
+++ b/Modules/vc-module-pricing/VirtoCommerce.PricingModule.Web/Module.cs
@@ -15,6 +15,7 @@ using VirtoCommerce.CoreModule.Core.Conditions.GeoConditions;
 using VirtoCommerce.ExportModule.Core.Model;
 using VirtoCommerce.ExportModule.Core.Services;
 using VirtoCommerce.ExportModule.Data.Extensions;
+using VirtoCommerce.ExportModule.Data.Services;
 using VirtoCommerce.Platform.Core.Bus;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
@@ -152,27 +153,35 @@ namespace VirtoCommerce.PricingModule.Web
             var pricelistExportPagedDataSourceFactory = appBuilder.ApplicationServices.GetService<Func<ExportDataQuery, PricelistExportPagedDataSource>>();
             var pricelistAssignmentExportPagedDataSourceFactory = appBuilder.ApplicationServices.GetService<Func<ExportDataQuery, PricelistAssignmentExportPagedDataSource>>();
 
-            registrar.RegisterType(typeof(Price).FullName, "Pricing", typeof(PriceExportDataQuery).Name)
-                .WithDataSourceFactory(dataQuery => priceExportPagedDataSourceFactory(dataQuery))
-                .WithMetadata(typeof(Price).GetPropertyNames(false))
-                .WithTabularDataConverter(new TabularPriceDataConverter())
-                .WithTabularMetadata(typeof(TabularPrice).GetPropertyNames(false));
+            registrar.RegisterType(
+                 ExportedTypeDefinitionBuilder.Build<Price, PriceExportDataQuery>()
+                    .WithDataSourceFactory(dataQuery => priceExportPagedDataSourceFactory(dataQuery))
+                    .WithMetadata(typeof(Price).GetPropertyNames(false))
+                    .WithTabularDataConverter(new TabularPriceDataConverter())
+                    .WithTabularMetadata(typeof(TabularPrice).GetPropertyNames(false))
+                    .ExportedTypeDefinition);
 
-            registrar.RegisterType(typeof(Pricelist).FullName, "Pricing", typeof(PricelistExportDataQuery).Name)
-                .WithDataSourceFactory(dataQuery => pricelistExportPagedDataSourceFactory(dataQuery))
-                .WithMetadata(typeof(Pricelist).GetPropertyNames(false))
-                .WithTabularDataConverter(new TabularPricelistDataConverter())
-                .WithTabularMetadata(typeof(TabularPricelist).GetPropertyNames(false));
+            registrar.RegisterType(
+                 ExportedTypeDefinitionBuilder.Build<Pricelist, PricelistExportDataQuery>()
+                    .WithDataSourceFactory(dataQuery => pricelistExportPagedDataSourceFactory(dataQuery))
+                    .WithMetadata(typeof(Pricelist).GetPropertyNames(false))
+                    .WithTabularDataConverter(new TabularPricelistDataConverter())
+                    .WithTabularMetadata(typeof(TabularPricelist).GetPropertyNames(false))
+                    .ExportedTypeDefinition);
 
-            registrar.RegisterType(typeof(PricelistAssignment).FullName, "Pricing", typeof(PricelistAssignmentExportDataQuery).Name)
-                .WithDataSourceFactory(dataQuery => pricelistAssignmentExportPagedDataSourceFactory(dataQuery))
-                .WithMetadata(typeof(PricelistAssignment).GetPropertyNames(false))
-                .WithTabularDataConverter(new TabularPricelistAssignmentDataConverter())
-                .WithTabularMetadata(typeof(TabularPricelistAssignment).GetPropertyNames(false));
+            registrar.RegisterType(
+                 ExportedTypeDefinitionBuilder.Build<PricelistAssignment, PricelistAssignmentExportDataQuery>()
+                    .WithDataSourceFactory(dataQuery => pricelistAssignmentExportPagedDataSourceFactory(dataQuery))
+                    .WithMetadata(typeof(PricelistAssignment).GetPropertyNames(false))
+                    .WithTabularDataConverter(new TabularPricelistAssignmentDataConverter())
+                    .WithTabularMetadata(typeof(TabularPricelistAssignment).GetPropertyNames(false))
+                    .ExportedTypeDefinition);
 
-            registrar.RegisterType($@"{typeof(Pricelist).FullName}FullData", "Pricing", typeof(PricelistFullExportDataQuery).Name)
-                .WithDataSourceFactory(dataQuery => pricelistExportPagedDataSourceFactory(dataQuery))
-                .WithMetadata(typeof(Pricelist).GetPropertyNames(true));
+            registrar.RegisterType(
+                new ExportedTypeDefinitionBuilder($@"{typeof(Pricelist).FullName}FullData", typeof(Pricelist).Namespace, typeof(PricelistFullExportDataQuery).Name)
+                    .WithDataSourceFactory(dataQuery => pricelistExportPagedDataSourceFactory(dataQuery))
+                    .WithMetadata(typeof(Pricelist).GetPropertyNames(true))
+                    .ExportedTypeDefinition);
 
             AbstractTypeFactory<ExportDataQuery>.RegisterType<PriceExportDataQuery>();
             AbstractTypeFactory<ExportDataQuery>.RegisterType<PricelistAssignmentExportDataQuery>();


### PR DESCRIPTION
Reworked ExportedTypeDefinition registration, left non generic way in case we want to specify different group for some type (e.g. Pricing object in Catalog group).