### PR TITLE
Fix startup exception when AzureAD is configured.

### DIFF
--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -177,7 +177,7 @@ namespace VirtoCommerce.Platform.Web
                 if (options.Enabled)
                 {
                     //TODO: Need to check how this influence to OpennIddict Reference tokens activated by this line below  AddValidation(options => options.UseReferenceTokens());
-                    var auth = services.AddAuthentication().AddOAuthValidation();
+                    var auth = services.AddAuthentication();
                     auth.AddOpenIdConnect(options.AuthenticationType, options.AuthenticationCaption,
                         openIdConnectOptions =>
                         {


### PR DESCRIPTION
If you configure Azure AD the following exception is thrown at startup:

Unhandled Exception: System.InvalidOperationException: The OpenIddict validation handler cannot be registered as an authentication scheme.
This may indicate that an instance of the OAuth validation or JWT bearer handler was registered.
Make sure that neither 'services.AddAuthentication().AddOAuthValidation()' nor 'services.AddAuthentication().AddJwtBearer()' are called from 'ConfigureServices'.

Removing the "AddOAuthValidation" line from the AddAuthentication allows AzureAD users to access the admin UI.