### PR TITLE
Check for null member id before removing.

### DIFF
--- a/Modules/vc-module-customer/VirtoCommerce.CustomerModule.Data/Caching/CustomerCacheRegion.cs
+++ b/Modules/vc-module-customer/VirtoCommerce.CustomerModule.Data/Caching/CustomerCacheRegion.cs
@@ -25,7 +25,7 @@ namespace VirtoCommerce.CustomerModule.Data.Caching
 
         public static void ExpireMemberById(string memberId)
         {
-            if (_memberRegionTokenLookup.TryRemove(memberId, out var token))
+            if (!string.IsNullOrEmpty(memberId) && _memberRegionTokenLookup.TryRemove(memberId, out var token))
             {
                 token.Cancel();
             }


### PR DESCRIPTION
Not all users have a member id.  This check prevents trying to remove a user that doesn't actually have a member id assigned.